### PR TITLE
Removed checksum tests as they only cause failures

### DIFF
--- a/automatic/_output/openra/2015.12.24/tools/chocolateyInstall.ps1
+++ b/automatic/_output/openra/2015.12.24/tools/chocolateyInstall.ps1
@@ -2,8 +2,6 @@
 $installerType = 'exe'
 $silentArgs = '/S'
 $url = 'https://github.com//OpenRA/OpenRA/releases/download/release-20151224/OpenRA-release-20151224.exe'
-$checksum = '857a0ea13b27b134db4f8328f7fcf510'
-$checksumType = 'md5'
 $validExitCodes = @(0)
 Install-ChocolateyPackage -PackageName "$packageName" `
                           -FileType "$installerType" `

--- a/automatic/_output/openra/2015.12.24/tools/chocolateyInstall.ps1
+++ b/automatic/_output/openra/2015.12.24/tools/chocolateyInstall.ps1
@@ -7,6 +7,4 @@ Install-ChocolateyPackage -PackageName "$packageName" `
                           -FileType "$installerType" `
                           -SilentArgs "$silentArgs" `
                           -Url "$url" `
-                          -ValidExitCodes $validExitCodes `
-                          -Checksum "$checksum" `
-                          -ChecksumType "$checksumType"
+                          -ValidExitCodes $validExitCodes

--- a/automatic/openra/tools/chocolateyInstall.ps1
+++ b/automatic/openra/tools/chocolateyInstall.ps1
@@ -2,8 +2,6 @@
 $installerType = 'exe'
 $silentArgs = '/S'
 $url = '{{DownloadUrl}}'
-$checksum = '{{Checksum}}'
-$checksumType = 'md5'
 $validExitCodes = @(0)
 Install-ChocolateyPackage -PackageName "$packageName" `
                           -FileType "$installerType" `

--- a/automatic/openra/tools/chocolateyInstall.ps1
+++ b/automatic/openra/tools/chocolateyInstall.ps1
@@ -7,6 +7,4 @@ Install-ChocolateyPackage -PackageName "$packageName" `
                           -FileType "$installerType" `
                           -SilentArgs "$silentArgs" `
                           -Url "$url" `
-                          -ValidExitCodes $validExitCodes `
-                          -Checksum "$checksum" `
-                          -ChecksumType "$checksumType"
+                          -ValidExitCodes $validExitCodes


### PR DESCRIPTION
Closes https://github.com/dtgm/chocolatey-packages/issues/57. NSIS does a file consistency check with checksums on it's own so this is redundant.