### PR TITLE
admin tag for bluescreenview.install

### DIFF
--- a/automatic/bluescreenview.install/bluescreenview.install.nuspec
+++ b/automatic/bluescreenview.install/bluescreenview.install.nuspec
@@ -19,7 +19,7 @@ BlueScreenView also mark the drivers that their addresses found in the crash sta
     <packageSourceUrl>https://github.com/dtgm/chocolatey-packages/tree/master/automatic/_output/{{PackageName}}/{{PackageVersion}}</packageSourceUrl>
     <projectUrl>http://www.nirsoft.net/utils/blue_screen_view.html</projectUrl>
     <iconUrl>https://cdn.rawgit.com/dtgm/chocolatey-packages/2697586f564894b3346352497da46f320a02e725/icons/bluescreenview.png</iconUrl>
-    <tags>bsod error crash stop dump minidump</tags>
+    <tags>bsod error crash stop dump minidump admin</tags>
     <copyright>© 2009 NirSoft</copyright>
     <licenseUrl>http://www.nirsoft.net/utils/blue_screen_view.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
This software requires UAC elevation / installers will require admin tag soon.