### PR TITLE
Fix regex for getting irfanview versions.

### DIFF
--- a/ketarin/irfanview.xml
+++ b/ketarin/irfanview.xml
@@ -114,7 +114,7 @@ http://www.irfanview.com/faq.htm#Q72</UserNotes>
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
-            <Regex>[^ "'&lt;&gt;\*]+\.exe</Regex>
+            <Regex>[^\ "'&lt;&gt;\*]+\.exe</Regex>
             <Url>http://www.fosshub.com/IrfanView.html</Url>
             <Name>urlFile</Name>
           </UrlVariable>
@@ -128,7 +128,7 @@ http://www.irfanview.com/faq.htm#Q72</UserNotes>
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
-            <Regex>[^ "'&lt;&gt;\*]+64_setup\.exe</Regex>
+            <Regex>[^\ "'&lt;&gt;\*]+64_setup\.exe</Regex>
             <Url>http://www.fosshub.com/IrfanView.html</Url>
             <Name>url64File</Name>
           </UrlVariable>


### PR DESCRIPTION
Markup may have changed on IrfanView homepage and an additional string
of "Irfanview.html" was getting pulled in by the regular expression.