### PR TITLE
Support direct versioned links to AWSCLI installer

### DIFF
--- a/ketarin/awscli.xml
+++ b/ketarin/awscli.xml
@@ -45,10 +45,10 @@ chocopkgup /p {appname}.install /v {version} /u "{preupdate-url}" /u64 "{url64}"
         <value>
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
-            <VariableType>RegularExpression</VariableType>
-            <Regex>[^ "'&lt;&gt;\*]+32\.msi</Regex>
-            <Url>{urlPath}</Url>
-            <TextualContent />
+            <VariableType>Textual</VariableType>
+            <Regex />
+            <Url />
+            <TextualContent>https://s3.amazonaws.com/aws-cli/AWSCLI32-{version}.msi<TextualContent>
             <Name>url</Name>
           </UrlVariable>
         </value>
@@ -60,10 +60,10 @@ chocopkgup /p {appname}.install /v {version} /u "{preupdate-url}" /u64 "{url64}"
         <value>
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
-            <VariableType>RegularExpression</VariableType>
-            <Regex>[^ "'&lt;&gt;\*]+64\.msi</Regex>
-            <Url>{urlPath}</Url>
-            <TextualContent />
+            <VariableType>Textual</VariableType>
+            <Regex />
+            <Url />
+            <TextualContent>https://s3.amazonaws.com/aws-cli/AWSCLI64-{version}.msi<TextualContent>
             <Name>url64</Name>
           </UrlVariable>
         </value>


### PR DESCRIPTION
Fixes https://github.com/dtgm/chocolatey-packages/issues/175

URL is based on information provided by aws-cli team: https://github.com/aws/aws-cli/issues/1921