### PR TITLE
Total Commander fixes

### DIFF
--- a/automatic/totalcommander/tools/chocolateyInstall.ps1
+++ b/automatic/totalcommander/tools/chocolateyInstall.ps1
@@ -88,7 +88,7 @@ $url64 = $url
 $checksum64 = $checksum
 $checksumType64 = $checksumType
 $installExeZip = Join-Path $tempDir "installer.zip"
-$installExeDir = Join-Path $tempDir "installer"
+$installExeSourceBasePath = Join-Path $tempDir "installer"
 Get-ChocolateyWebFile -PackageName "$packageName" `
                       -FileFullPath "$installExeZip" `
                       -Url "$url" `
@@ -98,7 +98,7 @@ Get-ChocolateyWebFile -PackageName "$packageName" `
                       -ChecksumType "$checksumType" `
                       -ChecksumType64 "$checksumType64"
 $proc = Start-Process -FilePath "7za" `
-                      -ArgumentList "x -y -o`"$installExeDir`" `"$installExeZip`"" `
+                      -ArgumentList "x -y -o`"$installExeSourceBasePath`" `"$installExeZip`"" `
                       -Wait `
                       -NoNewWindow `
                       -PassThru
@@ -110,14 +110,17 @@ if($exitCode -ne 0) {
 
 Write-Verbose "Add launcher to extracted EXE"
 if (Get-ProcessorBits 64) {
-  $bitWidth = 64
+  $installExeSourceLeafDir = '64'
+  $installExeTargetName = 'INSTALL64.EXE'
 } else {
-  $bitWidth = 32
+  $installExeSourceLeafDir = '32'
+  $installExeTargetName = 'INSTALL.EXE'
 }
-$installExePath = Join-Path -Path $installExeDir `
-                     -ChildPath $bitWidth | 
+$installExeSourcePath = Join-Path -Path $installExeSourceBasePath `
+                     -ChildPath $installExeSourceLeafDir |
                   Join-Path -ChildPath "INSTALL.EXE"
-Copy-Item $installExePath $tcmdWork -Force
+$installExeTargetPath = Join-Path $tcmdWork $installExeTargetName
+Copy-Item -Path $installExeSourcePath -Destination $installExeTargetPath -Force
 
 Write-Verbose "Modify install options to make silent"
 $installInf = Join-Path $tcmdWork "INSTALL.INF"
@@ -133,8 +136,7 @@ $installInf64 = Join-Path $tcmdWork "INSTALL64.INF"
                           -Replace 'mkdesktop=1',"$desktopIcon" `
                           -Replace 'Dir=c:\\totalcmd',"$installPath" | Set-Content $installInf64
 
-$tcmdExe = Join-Path $tcmdWork "INSTALL.EXE"
 Install-ChocolateyInstallPackage -PackageName "$packageName" `
                                  -FileType "$installerType" `
                                  -SilentArgs "$silentArgs" `
-                                 -File "$tcmdExe"
+                                 -File $installExeTargetPath

--- a/automatic/totalcommander/tools/chocolateyInstall.ps1
+++ b/automatic/totalcommander/tools/chocolateyInstall.ps1
@@ -49,8 +49,9 @@ if ($packageParameters) {
     }
 
     if ($arguments.ContainsKey("InstallPath")) {
-        Write-Host "You want to use a custom Installation Path"
-        $installPath = 'Dir=' + $arguments["InstallPath"]
+        $customInstallPath = $arguments["InstallPath"]
+        Write-Host "You want to use a custom Installation Path: ""$customInstallPath"""
+        $installPath = 'Dir=' + $customInstallPath
     }
 } else {
   Write-Debug "No Package Parameters passed in"

--- a/automatic/totalcommander/tools/chocolateyInstall.ps1
+++ b/automatic/totalcommander/tools/chocolateyInstall.ps1
@@ -19,7 +19,7 @@ $packageParameters = $env:chocolateyPackageParameters
 # To override the default options set below: /localUser /desktopIcon /installPath="c:\totalcmd"
 $localUser = 'UserName=*' #default: install for all users
 $desktopIcon = 'mkdesktop=0' #default: no desktop icon
-$installPath = '%ProgramFiles%\totalcmd'
+$installPath = 'Dir=%ProgramFiles%\totalcmd'
 
 # Parse packageParameters with regular expressions
 if ($packageParameters) {

--- a/automatic/totalcommander/tools/chocolateyUninstall.ahk
+++ b/automatic/totalcommander/tools/chocolateyUninstall.ahk
@@ -21,7 +21,7 @@ ControlClick, Button4, %winTitle2%, Remove configuration files
 ControlClick, Button5, %winTitle2%, Uninstall
 
 WinWait, %winTitle3%, Warning: This will, 20
-ControlClick, Button1, %winTitle3%, &Yes
+ControlClick, Button1, %winTitle3%, Warning: This will ; Yes
 
 WinWait, %winTitle3%, The following, 20
 ControlClick, Button1, %winTitle3%, OK

--- a/automatic/totalcommander/tools/chocolateyUninstall.ahk
+++ b/automatic/totalcommander/tools/chocolateyUninstall.ahk
@@ -26,7 +26,7 @@ ControlClick, Button1 ; Yes
 WinWait, %winTitle3%, The following, 20
 ControlClick, Button1 ; OK
 
-WinWait, %winTitle3%, , 20
+WinWait, %winTitle3%, Program removed, 20
 ControlClick, Button1 ; OK
 
 ExitApp

--- a/automatic/totalcommander/tools/chocolateyUninstall.ahk
+++ b/automatic/totalcommander/tools/chocolateyUninstall.ahk
@@ -14,19 +14,19 @@ winTitle2 = Uninstall Total Commander ahk_class #32770
 winTitle3 = Uninstall ahk_class #32770
 
 WinWait, %winTitle1%, Removes the program, 20
-ControlClick, Button1, %winTitle1%, &Uninstall
+ControlClick, Button1 ; &Uninstall
 
 WinWait, %winTitle2%, Uninstall Program, 20
-ControlClick, Button4, %winTitle2%, Remove configuration files
-ControlClick, Button5, %winTitle2%, Uninstall
+ControlClick, Button4 ; Remove configuration files
+ControlClick, Button5 ; Uninstall
 
 WinWait, %winTitle3%, Warning: This will, 20
-ControlClick, Button1, %winTitle3%, Warning: This will ; Yes
+ControlClick, Button1 ; Yes
 
 WinWait, %winTitle3%, The following, 20
-ControlClick, Button1, %winTitle3%, OK
+ControlClick, Button1 ; OK
 
 WinWait, %winTitle3%, , 20
-ControlClick, Button1, %winTitle3%, OK
+ControlClick, Button1 ; OK
 
 ExitApp


### PR DESCRIPTION
Fixes:
1) installation to default location
2) Start Menu icons and Programs and Features description on 64-bit OSes
3) uninstallation on non-English OSes