### PR TITLE
shimgen helper

### DIFF
--- a/automatic/nirlauncher/tools/chocolateyInstall.ps1
+++ b/automatic/nirlauncher/tools/chocolateyInstall.ps1
@@ -25,3 +25,7 @@ Get-ChocolateyUnzip -FileFullPath "$zipFile" `
 
 Set-Content -Path ("$installFile.gui") `
             -Value $null
+
+Get-ChildItem -Filter "*.exe" -Recurse -Path "$toolsdir\*" -Exclude @("nircmd.exe", "nircmdc.exe") | %{ 
+    New-Item ($_.FullName + ".gui") -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
shimgen nicely goes through all the executables but fails to identitfy them as "gui".  It would be nice not to be stuck with a non fonctionning command prompt everytime I fire up one of nir's utilities.  This adds an empty ".gui" file to every in tools and tools\64 save for "nircmd.exe" and "nircmdc.exe" which are "console" programs.