### PR TITLE
Update chocolateyUninstall.ps1

### DIFF
--- a/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
+++ b/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
@@ -1,16 +1,32 @@
 $packageName = 'spybot'
 $packageSearch = "Spybot - Search and Destroy*"
 $installerType = 'exe'
-$silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+$silentArgs = '/SILENT'
 $validExitCodes = @(0)
+											  
+	$spybot_string = "\SOFTWARE" + $bitness +"\Microsoft\Windows\CurrentVersion\Uninstall\{B4092C6D-E886-4CB2-BA68-FE5A99D31DE7}_is1"
+	$hive = "hkcu"
+	$Spybot = $hive + ":" + $spybot_string
 
-Get-ItemProperty -Path @('HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
-				                 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
-				                 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*') `
-                 -ErrorAction:SilentlyContinue `
-| Where-Object   {$_.DisplayName -like $packageSearch} `
-| ForEach-Object {Uninstall-ChocolateyPackage -PackageName "$packageName" `
-								                              -FileType "$installerType" `
-								                              -SilentArgs "$($silentArgs)" `
-								                              -File "$($_.UninstallString)" `
-                                              -ValidExitCodes $validExitCodes}
+
+	if (Test-Path $Spybot) {
+	  $hk_level = "hkcu"
+	} else {
+	  $hk_level = "hklm"
+	}
+
+	$bitness = Get-ProcessorBits
+	@{$true = "\WOW6432Node"; $false = ""}[$bitness -eq "64"]
+	
+	if (Test-Path $Spybot.QuietUninstallString) {
+	$spybot_uninstall_string = "QuietUninstallString"
+	$silentArgs = ""
+	} else {
+	$spybot_uninstall_string = "UninstallString"
+	}	
+
+	$file = (Get-ItemProperty -Path ( $hk_level + ":" +$spybot_string ) ).$spybot_uninstall_string
+
+return $file
+										  
+Uninstall-ChocolateyPackage -PackageName $packageName -FileType $installerType -SilentArgs $silentArgs -validExitCodes $validExitCodes -File $file

--- a/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
+++ b/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
@@ -1,12 +1,9 @@
 $packageName = 'spybot'
 $packageSearch = "Spybot - Search and Destroy*"
 $installerType = 'exe'
-#$silentArgs = '/SILENT'
-$validExitCodes = @(0)
+$silentArgs = '/SILENT'
 
-   [array]$spybot = Get-UninstallRegistryKey -SoftwareName "Spybot*"
- $file = $spybot.QuietUninstallString
-  if ( $null -eq $file ) { $file = $spybot.UninstallString }
-return $file
-										  
-Uninstall-ChocolateyPackage -PackageName $packageName -FileType $installerType -validExitCodes $validExitCodes -File $file
+$spybotreg = Get-UninstallRegistryKey -SoftwareName $packageSearch
+$spybot = $spybotreg.UninstallString
+									  
+Uninstall-ChocolateyPackage -PackageName $packageName -FileType $installerType -SilentArgs $silentArgs -File $spybot

--- a/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
+++ b/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
@@ -1,38 +1,12 @@
 $packageName = 'spybot'
 $packageSearch = "Spybot - Search and Destroy*"
 $installerType = 'exe'
-$silentArgs = '/SILENT'
+#$silentArgs = '/SILENT'
 $validExitCodes = @(0)
-											  
-	$spybot_string = "\SOFTWARE" + $bitty +"\Microsoft\Windows\CurrentVersion\Uninstall\{B4092C6D-E886-4CB2-BA68-FE5A99D31DE7}_is1"
-	$hive = "hkcu"
-	$Spybot = $hive + ":" + $spybot_string
 
-
-	if ( (Test-Path $Spybot) -eq $true ) {
-	  $hk_level = "hkcu"
-	} else {
-	  $hk_level = "hklm"
-	}
-
-	$bitness = Get-ProcessorBits
-	$bitty = @{$true = "\WOW6432Node"; $false = ""}[$bitness -eq "64"]
-	
-	if (Test-Path $Spybot.QuietUninstallString) {
-	  $spybot_uninstall_string = "QuietUninstallString"
-	  $silentArgs = ""
-	} else {
-	  $spybot_uninstall_string = "UninstallString"
-	}
-
-	if ( (Test-Path ( $hk_level + ":" +$spybot_string )) -eq $true ) {
-	  $spybot_key = ( $hk_level + ":" + $spybot_string )
-	} else  {
-	  $spybot_key = ( "hkcu:" + "\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{B4092C6D-E886-4CB2-BA68-FE5A99D31DE7}_is1" )
-    	}
-
-	$file = (Get-ItemProperty -Path ( $spybot_key ) ).$spybot_uninstall_string
-
-	return $file
+   [array]$spybot = Get-UninstallRegistryKey -SoftwareName "Spybot*"
+ $file = $spybot.QuietUninstallString
+  if ( $null -eq $file ) { $file = $spybot.UninstallString }
+return $file
 										  
-Uninstall-ChocolateyPackage -PackageName $packageName -FileType $installerType -SilentArgs $silentArgs -validExitCodes $validExitCodes -File $file
+Uninstall-ChocolateyPackage -PackageName $packageName -FileType $installerType -validExitCodes $validExitCodes -File $file

--- a/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
+++ b/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
@@ -4,29 +4,35 @@ $installerType = 'exe'
 $silentArgs = '/SILENT'
 $validExitCodes = @(0)
 											  
-	$spybot_string = "\SOFTWARE" + $bitness +"\Microsoft\Windows\CurrentVersion\Uninstall\{B4092C6D-E886-4CB2-BA68-FE5A99D31DE7}_is1"
+	$spybot_string = "\SOFTWARE" + $bitty +"\Microsoft\Windows\CurrentVersion\Uninstall\{B4092C6D-E886-4CB2-BA68-FE5A99D31DE7}_is1"
 	$hive = "hkcu"
 	$Spybot = $hive + ":" + $spybot_string
 
 
-	if (Test-Path $Spybot) {
+	if ( (Test-Path $Spybot) -eq $true ) {
 	  $hk_level = "hkcu"
 	} else {
 	  $hk_level = "hklm"
 	}
 
 	$bitness = Get-ProcessorBits
-	@{$true = "\WOW6432Node"; $false = ""}[$bitness -eq "64"]
+	$bitty = @{$true = "\WOW6432Node"; $false = ""}[$bitness -eq "64"]
 	
 	if (Test-Path $Spybot.QuietUninstallString) {
-	$spybot_uninstall_string = "QuietUninstallString"
-	$silentArgs = ""
+	  $spybot_uninstall_string = "QuietUninstallString"
+	  $silentArgs = ""
 	} else {
-	$spybot_uninstall_string = "UninstallString"
-	}	
+	  $spybot_uninstall_string = "UninstallString"
+	}
 
-	$file = (Get-ItemProperty -Path ( $hk_level + ":" +$spybot_string ) ).$spybot_uninstall_string
+	if ( (Test-Path ( $hk_level + ":" +$spybot_string )) -eq $true ) {
+	  $spybot_key = ( $hk_level + ":" + $spybot_string )
+	} else  {
+	  $spybot_key = ( "hkcu:" + "\SOFTWARE" + $bitty +"\Microsoft\Windows\CurrentVersion\Uninstall\{B4092C6D-E886-4CB2-BA68-FE5A99D31DE7}_is1" )
+    	}
 
-return $file
+	$file = (Get-ItemProperty -Path ( $spybot_key ) ).$spybot_uninstall_string
+
+	return $file
 										  
 Uninstall-ChocolateyPackage -PackageName $packageName -FileType $installerType -SilentArgs $silentArgs -validExitCodes $validExitCodes -File $file

--- a/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
+++ b/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
@@ -28,7 +28,7 @@ $validExitCodes = @(0)
 	if ( (Test-Path ( $hk_level + ":" +$spybot_string )) -eq $true ) {
 	  $spybot_key = ( $hk_level + ":" + $spybot_string )
 	} else  {
-	  $spybot_key = ( "hkcu:" + "\SOFTWARE" + $bitty +"\Microsoft\Windows\CurrentVersion\Uninstall\{B4092C6D-E886-4CB2-BA68-FE5A99D31DE7}_is1" )
+	  $spybot_key = ( "hkcu:" + "\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{B4092C6D-E886-4CB2-BA68-FE5A99D31DE7}_is1" )
     	}
 
 	$file = (Get-ItemProperty -Path ( $spybot_key ) ).$spybot_uninstall_string

--- a/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
+++ b/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
@@ -1,18 +1,17 @@
 $packageName = 'spybot'
 $packageSearch = "Spybot - Search and Destroy*"
 $installerType = 'exe'
--$silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
--$validExitCodes = @(0)
-$silentArgs = '/SILENT'
+$silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+$validExitCodes = @(0)
 
 $spybotreg = Get-UninstallRegistryKey -SoftwareName $packageSearch
--Get-ItemProperty -Path @('HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
--				                 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
--				                 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*') `
--                 -ErrorAction:SilentlyContinue `
--| Where-Object   {$_.DisplayName -like $packageSearch} `
--| ForEach-Object {Uninstall-ChocolateyPackage -PackageName "$packageName" `
--								                              -FileType "$installerType" `
--								                              -SilentArgs "$($silentArgs)" `
--								                              -File "$($_.UninstallString)" `
--                                              -ValidExitCodes $validExitCodes}
+Get-ItemProperty -Path @('HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
+				                 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
+				                 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*') `
+                 -ErrorAction:SilentlyContinue `
+| Where-Object   {$_.DisplayName -like $packageSearch} `
+| ForEach-Object {Uninstall-ChocolateyPackage -PackageName "$packageName" `
+								                              -FileType "$installerType" `
+								                              -SilentArgs "$($silentArgs)" `
+								                              -File "$($_.UninstallString)" `
+                                              -ValidExitCodes $validExitCodes}

--- a/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
+++ b/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
@@ -1,9 +1,18 @@
 $packageName = 'spybot'
 $packageSearch = "Spybot - Search and Destroy*"
 $installerType = 'exe'
+-$silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
+-$validExitCodes = @(0)
 $silentArgs = '/SILENT'
 
 $spybotreg = Get-UninstallRegistryKey -SoftwareName $packageSearch
-$spybot = $spybotreg.UninstallString
-									  
-Uninstall-ChocolateyPackage -PackageName $packageName -FileType $installerType -SilentArgs $silentArgs -File $spybot
+-Get-ItemProperty -Path @('HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
+-				                 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
+-				                 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*') `
+-                 -ErrorAction:SilentlyContinue `
+-| Where-Object   {$_.DisplayName -like $packageSearch} `
+-| ForEach-Object {Uninstall-ChocolateyPackage -PackageName "$packageName" `
+-								                              -FileType "$installerType" `
+-								                              -SilentArgs "$($silentArgs)" `
+-								                              -File "$($_.UninstallString)" `
+-                                              -ValidExitCodes $validExitCodes}

--- a/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
+++ b/automatic/_output/spybot/2.4.40.20160327/tools/chocolateyUninstall.ps1
@@ -4,7 +4,6 @@ $installerType = 'exe'
 $silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
 $validExitCodes = @(0)
 
-$spybotreg = Get-UninstallRegistryKey -SoftwareName $packageSearch
 Get-ItemProperty -Path @('HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
 				                 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
 				                 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*') `

--- a/automatic/spybot/tools/chocolateyUninstall.ps1
+++ b/automatic/spybot/tools/chocolateyUninstall.ps1
@@ -1,16 +1,9 @@
-﻿$packageName = '{{PackageName}}'
+$packageName = '{{PackageName}}'
 $packageSearch = "Spybot - Search and Destroy*"
 $installerType = 'exe'
-$silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
-$validExitCodes = @(0)
+$silentArgs = '/SILENT'
 
-Get-ItemProperty -Path @('HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
-				                 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
-				                 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*') `
-                 -ErrorAction:SilentlyContinue `
-| Where-Object   {$_.DisplayName -like $packageSearch} `
-| ForEach-Object {Uninstall-ChocolateyPackage -PackageName "$packageName" `
-								                              -FileType "$installerType" `
-								                              -SilentArgs "$($silentArgs)" `
-								                              -File "$($_.UninstallString.Replace('"',''))" `
-                                              -ValidExitCodes $validExitCodes}
+$spybotreg = Get-UninstallRegistryKey -SoftwareName $packageSearch
+$spybot = $spybotreg.UninstallString
+									  
+Uninstall-ChocolateyPackage -PackageName $packageName -FileType $installerType -SilentArgs $silentArgs -File $spybot


### PR DESCRIPTION
Spybot 2 changed the location in the registry to be a Hive name; This will find the correct hive name, and choose the correct uninstall file with Silent Argument.
Should work except for the extremely rare chance they have a 32bit install on a 64bit system under hkcu
