### PR TITLE
Updated keepass-plugin-keeanywhere to reflect upcomin V 1.3.0

### DIFF
--- a/automatic/keepass-plugin-keeanywhere/keepass-plugin-keeanywhere.nuspec
+++ b/automatic/keepass-plugin-keeanywhere/keepass-plugin-keeanywhere.nuspec
@@ -12,7 +12,6 @@ KeeAnywhere is a KeePass plugin that provides access to cloud storage providers 
 
 Supported providers:
 
-* Amazon Drive
 * Amazon AWS S3
 * Box
 * Dropbox

--- a/automatic/keepass-plugin-keeanywhere/keepass-plugin-keeanywhere.nuspec
+++ b/automatic/keepass-plugin-keeanywhere/keepass-plugin-keeanywhere.nuspec
@@ -12,6 +12,9 @@ KeeAnywhere is a KeePass plugin that provides access to cloud storage providers 
 
 Supported providers:
 
+* Amazon Drive
+* Amazon AWS S3
+* Box
 * Dropbox
 * Google Drive
 * hubiC
@@ -24,7 +27,7 @@ Supported providers:
     <docsUrl>https://github.com/Kyrodan/KeeAnywhere/wiki/</docsUrl>
     <iconUrl>https://cdn.rawgit.com/Kyrodan/KeeAnywhere/95b05e59b80690037bfb1952715d5104fbf99b71/KeeAnywhere/Resources/KeeAnywhere_48x48.png</iconUrl>
     <tags>keepass plugin backup sync cloud</tags>
-    <copyright>© 2015 Daniel Bölts</copyright>
+    <copyright>© 2015-2016 Daniel Bölts</copyright>
     <licenseUrl>https://github.com/Kyrodan/KeeAnywhere/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>
@@ -36,7 +39,7 @@ Supported providers:
     </releaseNotes>
     <dependencies>
       <dependency id="keepass" version="[2.31, 3.0)" />
-      <dependency id="dotnet4.5" />
+      <dependency id="dotnet4.5.1" />
     </dependencies>
   </metadata>
   <files>

--- a/automatic/keepass-plugin-keeanywhere/keepass-plugin-keeanywhere.nuspec
+++ b/automatic/keepass-plugin-keeanywhere/keepass-plugin-keeanywhere.nuspec
@@ -17,6 +17,7 @@ Supported providers:
 * Box
 * Dropbox
 * Google Drive
+* HiDrive
 * hubiC
 * OneDrive
     </description>


### PR DESCRIPTION
Upcoming KeeAnywhere has
* new providers - changed description
* .Net 4.5.1 (instead of 4.5) as prerequisite