### PR TITLE
Fix FossHub genLink URLs.

### DIFF
--- a/ketarin/datacrow.xml
+++ b/ketarin/datacrow.xml
@@ -88,7 +88,7 @@
             <VariableType>Textual</VariableType>
             <Regex />
             <Url />
-            <TextualContent>http://www.fosshub.com/genLink/Data-Crow</TextualContent>
+            <TextualContent>http://www.fosshub.com/Data-Crow.html</TextualContent>
             <Name>urlHost</Name>
           </UrlVariable>
         </value>

--- a/ketarin/irfanview.xml
+++ b/ketarin/irfanview.xml
@@ -101,7 +101,7 @@ http://www.irfanview.com/faq.htm#Q72</UserNotes>
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>Textual</VariableType>
             <Regex />
-            <TextualContent>http://www.fosshub.com/genLink/IrfanView</TextualContent>
+            <TextualContent>http://www.fosshub.com/IrfanView.html</TextualContent>
             <Name>urlHost</Name>
           </UrlVariable>
         </value>


### PR DESCRIPTION
I'm not sure I did this correctly since I didn't set up Ketarin to test.  I also wanted to make sure to mention that your version of the MKVtoolNix seems to need to move away from FossHub genLink URLs but I wasn't quite sure how that should happen.  It also isn't the authoritative package according to chocolatey.org's packages index.  There are also instances in all.xml of genLink URLs but I wasn't sure if that was a generated file.  Perhaps they could be updated to support installing previous versions?

[I tried](https://github.com/chocolatey/chocolatey-coreteampackages/pull/324) to get an [automatic migration](https://github.com/opello/chocolatey-coreteampackages/commit/baa6dcf48badee708e0289f9f9a911506f662a8d) into the chocolatey-fosshub.extension but it wasn't desired.
