### PR TITLE
Update FreeFileSync fixes #278

### DIFF
--- a/automatic/freefilesync/tools/chocolateyInstall.ps1
+++ b/automatic/freefilesync/tools/chocolateyInstall.ps1
@@ -1,15 +1,17 @@
-﻿$packageName = '{{PackageName}}'
+$packageName = '{{PackageName}}'
 $installerType = 'exe'
 $silentArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
 $url = '{{DownloadUrl}}'
 $checksum = '{{Checksum}}'
 $checksumType = 'sha256'
 $validExitCodes = @(0)
+$userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.0 (KHTML, like Gecko) Chrome/42.0 Safari/537.0 Edge/12.0'
+$file = "$env:TEMP\FreeFileSync_Windows_Setup.exe"
 
-Install-ChocolateyPackage -PackageName "$packageName" `
-                          -FileType "$installerType" `
-                          -SilentArgs "$silentArgs" `
-                          -Url "$url" `
-                          -ValidExitCodes $validExitCodes `
-                          -Checksum "$checksum" `
-                          -ChecksumType "$checksumType"
+Get-WebFile "$url" "$file" "$userAgent"
+
+Install-ChocolateyInstallPackage -PackageName "$packageName" `
+                                 -FileType "$installerType" `
+                                 -SilentArgs "$silentArgs" `
+                                 -File "$file" `
+                                 -ValidExitCodes $validExitCodes `


### PR DESCRIPTION
This fixes the `Access Denied` error

__BUT__ - There is another problem with the installer. The installer can no longer run in silent mode.

It needs AutoIt or AutoHotkey.