### PR TITLE
(kodi) Update download url, avoid RCs

### DIFF
--- a/ketarin/kodi.xml
+++ b/ketarin/kodi.xml
@@ -71,8 +71,8 @@
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
-            <Regex>[^ "'&lt;&gt;\*]+\.exe</Regex>
-            <Url>http://kodi.tv/download/</Url>
+            <Regex>[^ "'&lt;&gt;\*]+(?<!_rc.)\.exe</Regex>
+            <Url>http://mirrors.kodi.tv/releases/win32/</Url>
             <Name>urlPath</Name>
           </UrlVariable>
         </value>

--- a/ketarin/kodi.xml
+++ b/ketarin/kodi.xml
@@ -57,7 +57,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
             <Regex>(?&lt;=ResponseUri: )[^\r\n]+</Regex>
-            <Url>{urlPath}</Url>
+            <Url>http://mirrors.kodi.tv/releases/win32/{urlPath}</Url>
             <TextualContent />
             <Name>url</Name>
           </UrlVariable>
@@ -101,7 +101,7 @@
             <VariableType>Textual</VariableType>
             <Regex />
             <Url />
-            <TextualContent>{urlPath}</TextualContent>
+            <TextualContent>http://mirrors.kodi.tv/releases/win32/{urlPath}</TextualContent>
             <Name>url64</Name>
           </UrlVariable>
         </value>


### PR DESCRIPTION
I'm guessing the download page changed at some point, the links to installers are now behind an OS selection dialog and not present on the main page.

Should also address complaints about selecting release candidates.

Please note I don't use Ketarin myself so I hope I haven't made any obvious mistakes.