### PR TITLE
distinguish between win32/win64 for cmake.install

### DIFF
--- a/automatic/cmake.install/tools/chocolateyInstall.ps1
+++ b/automatic/cmake.install/tools/chocolateyInstall.ps1
@@ -4,12 +4,18 @@ $silentArgs = '/quiet /qn /norestart'
 $url = '{{DownloadUrl}}'
 $checksum = '{{Checksum}}'
 $checksumType = 'sha256'
+$url64 = '{{DownloadUrlx64}}'
+$checksum64 = '{{Checksumx64}}'
+$checksumType64 = 'sha256'
 $validExitCodes = @(0,3010)
 
 Install-ChocolateyPackage -PackageName "$packageName" `
                           -FileType "$installerType" `
                           -SilentArgs "$silentArgs" `
-                          -Url "$url" `
                           -ValidExitCodes $validExitCodes `
+                          -Url "$url" `
                           -Checksum "$checksum" `
-                          -ChecksumType "$checksumType"
+                          -ChecksumType "$checksumType" `
+                          -Url64bit "$url64" `
+                          -Checksum64 "$checksum64" `
+                          -ChecksumType64 "$checksumType64"

--- a/ketarin/cmake.install.xml
+++ b/ketarin/cmake.install.xml
@@ -70,9 +70,23 @@
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
-            <Regex>/?([^ "'&lt;&gt;\*]+\.msi)</Regex>
+            <Regex>/?([^ "'&lt;&gt;\*]+-win32-x86\.msi)</Regex>
             <Url>http://www.cmake.org/download/</Url>
             <Name>urlPath</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>urlPath64</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>RegularExpression</VariableType>
+            <Regex>/?([^ "'&lt;&gt;\*]+-win64-x64\.msi)</Regex>
+            <Url>http://www.cmake.org/download/</Url>
+            <Name>urlPath64</Name>
           </UrlVariable>
         </value>
       </item>
@@ -101,6 +115,34 @@
             <Regex />
             <TextualContent>2</TextualContent>
             <Name>cscript</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>checksum64file</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>Textual</VariableType>
+            <Regex />
+            <TextualContent>{url64}</TextualContent>
+            <Name>checksum64file</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>url64</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>Textual</VariableType>
+            <Regex />
+            <TextualContent>{urlHost}/{urlPath64}</TextualContent>
+            <Name>url64</Name>
           </UrlVariable>
         </value>
       </item>


### PR DESCRIPTION
this should add the win32 installer to url and the win64 installer to url64 making cmake.install available for 32-bit windows and probably fix #317

I tested it with keratin and modified chocolateyInstall.ps1 accordingly

HOWEVER, I don't really got chocpkgup working.  Where is this documented?