### PR TITLE
Fix "cast is not valid" in Telegram uninstall

### DIFF
--- a/automatic/telegram.install/tools/chocolateyUninstall.ps1
+++ b/automatic/telegram.install/tools/chocolateyUninstall.ps1
@@ -6,7 +6,7 @@ $validExitCodes = @(0)
 Get-ItemProperty -Path @( 'HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
                           'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
                           'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*' ) `
-                 -ErrorAction:SilentlyContinue `
+                 -Name DisplayName,UninstallString -ErrorAction:SilentlyContinue `
 | Where-Object   { $_.DisplayName -like $packageSearch } `
 | ForEach-Object { Uninstall-ChocolateyPackage -PackageName "$packageName" `
                                                -FileType "$installerType" `


### PR DESCRIPTION
I suspect registry keys with no properties cause "Specified cast is not valid" in Get-ItemProperty:
https://gist.github.com/fizmat/afa889a5a3b8783e6e4b18cf81d620a2