### PR TITLE
change in the download link for stunnel

### DIFF
--- a/ketarin/stunnel.xml
+++ b/ketarin/stunnel.xml
@@ -76,7 +76,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>Textual</VariableType>
             <Regex />
-            <TextualContent>https://www.stunnel.org/downloads/archive/{version:split:.:0}.x/stunnel-{version}-installer.exe</TextualContent>
+            <TextualContent>https://www.stunnel.org/downloads/archive/{version:split:.:0}.x/stunnel-{version}-win32-installer.exe</TextualContent>
             <Name>url</Name>
           </UrlVariable>
         </value>


### PR DESCRIPTION
There seems to be a change in the filename that need to be downloaded - https://www.stunnel.org/downloads/archive/5.x/stunnel-5.44-win32-installer.exe for example.