### PR TITLE
fixes #235: bitvise-ssh-server uninstall failure

### DIFF
--- a/automatic/bitvise-ssh-server/tools/chocolateyUninstall.ps1
+++ b/automatic/bitvise-ssh-server/tools/chocolateyUninstall.ps1
@@ -1,15 +1,29 @@
-﻿$packageName = '{{PackageName}}'
-$softwareName = "Bitvise SSH Server*"
-$installerType = 'exe'
-$silentArgs = '/S'
-$validExitCodes = @(0)
+﻿$ErrorActionPreference = 'Stop'; # stop on all errors
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  softwareName  = 'Bitvise SSH Server*'
+  fileType      = 'exe'
+  silentArgs    = "-unat"
+  validExitCodes= @(0, 1) # unattended uninstall exits with code 1
+}
 
-[array]$key = Get-UninstallRegistryKey -SoftwareName $softwareName
+$uninstalled = $false
 
-$key | ForEach-Object {
-  Uninstall-ChocolateyPackage -PackageName "$packageName" `
-                              -FileType "$installerType" `
-                              -SilentArgs "$($silentArgs)" `
-                              -File "& $($_.UninstallString.Replace('"',''))" `
-                              -ValidExitCodes $validExitCodes
+[array]$key = Get-UninstallRegistryKey -SoftwareName $packageArgs['softwareName']
+
+if ($key.Count -eq 1) {
+  $key | % {
+    $packageArgs['file'] = "$($_.DisplayIcon)" # contains path to uninst.exe
+    # uninst.exe needs product name as an additional parameter for uninstallation
+    $packageArgs['silentArgs'] = "`"$($_.ProductName)`" $($packageArgs['silentArgs'])"
+
+    Uninstall-ChocolateyPackage @packageArgs
+  }
+} elseif ($key.Count -eq 0) {
+  Write-Warning "$packageName has already been uninstalled by other means."
+} elseif ($key.Count -gt 1) {
+  Write-Warning "$($key.Count) matches found!"
+  Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
+  Write-Warning "Please alert package maintainer the following keys were matched:"
+  $key | % {Write-Warning "- $($_.DisplayName)"}
 }


### PR DESCRIPTION
I've fixed the uninstall script and updated it to the latest template. The problem was that the `uninstallString` also contains the product name to uninstall as an additional argument so we cannot use it directly for the `-file` parameter.
I've instead used the registry properties `displayIcon` (contains only the path to the uninstall exe) and `productName` as an additional silent argument. Splitting the `uninstallString` property would require a more complex regexp which I would avoid in this case for readability reasons...

    DisplayIcon     : C:\Program Files\Bitvise SSH Server\uninst.exe
    UninstallString : "C:\Program Files\Bitvise SSH Server\uninst.exe" "Bitvise SSH Server"
    ProductName     : Bitvise SSH Server