### PR TITLE
Fix issue with Compass in 3.6.0 and add Mongo as a service

### DIFF
--- a/automatic/mongodb.install/tools/chocolateyInstall.ps1
+++ b/automatic/mongodb.install/tools/chocolateyInstall.ps1
@@ -1,10 +1,20 @@
 ﻿$packageName = '{{PackageName}}'
 $installerType = 'msi'
-$silentArgs = '/quiet /qn /norestart'
+# Compass causes a 1603 error when running the 3.6.0 MSI
+$silentArgs = '/quiet /qn /norestart SHOULD_INSTALL_COMPASS="0"'
 $url = '{{DownloadUrl}}'
 $checksum = '{{Checksum}}'
 $checksumType = 'sha256'
 $validExitCodes = @(0,3010)
+
+# Allow the user to specify the data and log path, falling back to sensible defaults
+$pp = Get-PackageParameters
+if(!$pp['dataPath']) { 
+    $pp['dataPath'] = "$env:PROGRAMDATA\MongoDB\data\db"
+}
+if(!$pp['logPath']) { 
+    $pp['logPath'] = "$env:PROGRAMDATA\MongoDB\log"
+}
 
 Install-ChocolateyPackage -PackageName "$packageName" `
                           -FileType "$installerType" `
@@ -13,3 +23,34 @@ Install-ChocolateyPackage -PackageName "$packageName" `
                           -ValidExitCodes $validExitCodes `
                           -Checksum "$checksum" `
                           -ChecksumType "$checksumType"
+
+# 
+New-Item -ItemType Directory $pp['dataPath'] -ErrorAction SilentlyContinue
+New-Item -ItemType Directory $pp['logPath'] -ErrorAction SilentlyContinue
+
+$Path = "$env:ProgramFiles\MongoDB\Server"
+$version = Get-ChildItem $Path | Sort-Object -Descending | Select-Object -First 1
+$configFilePath = "$Path\$version\mongod.cfg"
+
+# don't overwrite the config file if it already exists
+if (!(Test-Path $configFilePath))
+{
+    # put the parameters into vars so I can insert them into $configFile herestring
+    $dataPath = $pp['dataPath']
+    $logPath = $pp['logPath']
+    
+    $configFile = @"
+    systemLog:
+        destination: file
+        path: $logPath\mongod.log
+    storage:
+        dbPath: $dataPath
+"@
+
+    Add-Content -Path $configFilePath -Value $configFile
+}    
+
+# register MongoDB server as a Windows Service
+Invoke-Command "$Path\$version\bin\mongod.exe --config '$Path\$version\mongod.cfg' --install"
+# start the service
+Start-Service -Name MongoDB

--- a/automatic/mongodb.install/tools/chocolateyInstall.ps1
+++ b/automatic/mongodb.install/tools/chocolateyInstall.ps1
@@ -51,6 +51,6 @@ if (!(Test-Path $configFilePath))
 }    
 
 # register MongoDB server as a Windows Service
-Invoke-Command "$Path\$version\bin\mongod.exe --config '$Path\$version\mongod.cfg' --install"
+& "$Path\$version\bin\mongod.exe" --config "$Path\$version\mongod.cfg" --install
 # start the service
 Start-Service -Name MongoDB

--- a/automatic/mongodb.install/tools/chocolateyUninstall.ps1
+++ b/automatic/mongodb.install/tools/chocolateyUninstall.ps1
@@ -4,6 +4,23 @@ $installerType = 'msi'
 $silentArgs = '/quiet /qn /norestart'
 $validExitCodes = @(0,3010)
 
+If (Get-Service MongoDB)
+{
+    # need to find where mongod.exe lives in order to remove the service
+    $ServicePath = (Get-CIMInstance win32_service -filter 'Name like "%MongoDB%"').PathName
+    # split the path by spaces, except where the space is in between quotes.  Remove quotes from either side
+    $MongodPath = ($ServicePath -split ' (?=(?:[^"]|"[^"]*")*$)')[0].Replace("""", "")
+
+    if (Test-Path $MongodPath)
+    {
+        & $MongodPath --remove
+    }
+
+    # Should we remove the config too?
+    #$MongodCfg = ($ServicePath -split ' (?=(?:[^"]|"[^"]*")*$)')[2]    
+    #Remove-Item $MongodCfg
+}
+
 Get-ItemProperty -Path @('HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
                          'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
                          'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*') `


### PR DESCRIPTION
Currently the 3.6.0 MSI fails to install with a 1603 error, seems to work if Compass is not installed.  I've set a flag to turn that off.

Additionally I've added some logic to register Mongo DB as a service, along with setting default reasonable locations for the dataPath and dataLog, which can be overridden as package parameters

Not completely happy about the way the location of Mongo is determined, I'm using TARGETDIR to make this deterministic.  Also not sure how you're filling in the automatic details, as I can't see the usual AU scripts for each package in this repo.

Comments & feedback welcome :)
