### PR TITLE
Updated ManicTime links to https

### DIFF
--- a/ketarin/manictime.install.xml
+++ b/ketarin/manictime.install.xml
@@ -42,7 +42,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
             <Regex>(?&lt;=&lt;b&gt;&lt;span&gt;v&lt;/span&gt;)[\d\.]+</Regex>
-            <Url>http://www.manictime.com/Download/</Url>
+            <Url>https://www.manictime.com/Download/</Url>
             <Name>version</Name>
           </UrlVariable>
         </value>
@@ -70,7 +70,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
             <Regex>[^ "'&lt;&gt;\*]+\.msi</Regex>
-            <Url>http://www.manictime.com/Download/</Url>
+            <Url>https://www.manictime.com/Download/</Url>
             <Name>getUrl</Name>
           </UrlVariable>
         </value>

--- a/ketarin/manictime.portable.xml
+++ b/ketarin/manictime.portable.xml
@@ -42,7 +42,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
             <Regex>(?&lt;=&lt;b&gt;&lt;span&gt;v&lt;/span&gt;)[\d\.]+</Regex>
-            <Url>http://www.manictime.com/Download/</Url>
+            <Url>https://www.manictime.com/Download/</Url>
             <Name>version</Name>
           </UrlVariable>
         </value>
@@ -70,7 +70,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
             <Regex>[^ "'&lt;&gt;\*]+\.zip</Regex>
-            <Url>http://www.manictime.com/Download/</Url>
+            <Url>https://www.manictime.com/Download/</Url>
             <Name>getUrl</Name>
           </UrlVariable>
         </value>

--- a/ketarin/manictime.xml
+++ b/ketarin/manictime.xml
@@ -42,7 +42,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
             <Regex>(?&lt;=&lt;b&gt;&lt;span&gt;v&lt;/span&gt;)[\d\.]+</Regex>
-            <Url>http://www.manictime.com/Download/</Url>
+            <Url>https://www.manictime.com/Download/</Url>
             <Name>version</Name>
           </UrlVariable>
         </value>
@@ -70,7 +70,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
             <Regex>[^ "'&lt;&gt;\*]+\.msi</Regex>
-            <Url>http://www.manictime.com/Download/</Url>
+            <Url>https://www.manictime.com/Download/</Url>
             <Name>getUrl</Name>
           </UrlVariable>
         </value>


### PR DESCRIPTION
Hey

ManicTime team switched to https only, so I updated the links.
The regular expressions didn't have to be changed.